### PR TITLE
Add Send Block with parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ dependencyResolutionManagement {
 ```
 
 2. Add dependency to your project level `build.gradle` file
-   ```
+```
    // Use when you use Ktor2 or other networking libs
    implementation("ai.koda.mobile.sdk:koda-core:<latest_version>")
    

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -137,7 +137,7 @@ afterEvaluate {
                 from components.release
                 groupId = 'ai.koda.mobile.sdk'
                 artifactId = 'koda-core'
-                version = '1.2.1'
+                version = '1.3.0'
             }
         }
     }

--- a/core/src/main/java/ai/koda/mobile/sdk/core/KodaBotsWebViewFragment.kt
+++ b/core/src/main/java/ai/koda/mobile/sdk/core/KodaBotsWebViewFragment.kt
@@ -326,6 +326,17 @@ class KodaBotsWebViewFragment : Fragment(R.layout.fragment_koda_bots_webview), F
         }
     }
 
+    fun sendBlock(blockId: String, token: String): Boolean {
+        return if (isReady) {
+            binding?.fragmentKodaBotsWebview?.callJavascript(
+                "KodaBots.sentBlock(\"${blockId}\", {token: \"${token}\"});"
+            )
+            true
+        } else {
+            false
+        }
+    }
+
     /**
      * Method used to set new user profile
      *

--- a/core/src/main/java/ai/koda/mobile/sdk/core/KodaBotsWebViewFragment.kt
+++ b/core/src/main/java/ai/koda/mobile/sdk/core/KodaBotsWebViewFragment.kt
@@ -314,17 +314,28 @@ class KodaBotsWebViewFragment : Fragment(R.layout.fragment_koda_bots_webview), F
      * Method used to send conversation blockId
      *
      * @param blockId Conversation block id
-     * @param params Additional parameters String to String
+     * @param params Additional custom parameters
      * @return true if invoked
      */
     fun sendBlock(blockId: String, params: Map<String, String>? = null): Boolean {
-        val paramsJson = Json.encodeToString(params)
+        return params?.let {
+            if (params.isNotEmpty()) {
+                val paramsJson = Json.encodeToString(params)
+                return if (isReady) {
+                    binding?.fragmentKodaBotsWebview?.callJavascript(
+                        "KodaBots.sentBlock(\"${blockId}\", ${paramsJson});"
+                    )
+                    true
+                } else {
+                    false
+                }
+            } else null
+        } ?: sendBlock(blockId)
+    }
+
+    private fun sendBlock(blockId: String): Boolean {
         return if (isReady) {
-            params?.let {
-                binding?.fragmentKodaBotsWebview?.callJavascript(
-                    "KodaBots.sentBlock(\"${blockId}\", ${paramsJson});"
-                )
-            } ?: binding?.fragmentKodaBotsWebview?.callJavascript(
+            binding?.fragmentKodaBotsWebview?.callJavascript(
                 "KodaBots.sentBlock(\"${blockId}\");"
             )
             true

--- a/core/src/main/java/ai/koda/mobile/sdk/core/KodaBotsWebViewFragment.kt
+++ b/core/src/main/java/ai/koda/mobile/sdk/core/KodaBotsWebViewFragment.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.io.File
 import java.util.concurrent.TimeUnit
@@ -313,23 +314,18 @@ class KodaBotsWebViewFragment : Fragment(R.layout.fragment_koda_bots_webview), F
      * Method used to send conversation blockId
      *
      * @param blockId Conversation block id
+     * @param params Additional parameters String to String
      * @return true if invoked
      */
-    fun sendBlock(blockId: String): Boolean {
+    fun sendBlock(blockId: String, params: Map<String, String>? = null): Boolean {
+        val paramsJson = Json.encodeToString(params)
         return if (isReady) {
-            binding?.fragmentKodaBotsWebview?.callJavascript(
+            params?.let {
+                binding?.fragmentKodaBotsWebview?.callJavascript(
+                    "KodaBots.sentBlock(\"${blockId}\", ${paramsJson});"
+                )
+            } ?: binding?.fragmentKodaBotsWebview?.callJavascript(
                 "KodaBots.sentBlock(\"${blockId}\");"
-            )
-            true
-        } else {
-            false
-        }
-    }
-
-    fun sendBlock(blockId: String, token: String): Boolean {
-        return if (isReady) {
-            binding?.fragmentKodaBotsWebview?.callJavascript(
-                "KodaBots.sentBlock(\"${blockId}\", {token: \"${token}\"});"
             )
             true
         } else {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,8 @@
 [versions]
 artifactregistry-gradle-plugin-version = "2.2.1"
-koda-core = "1.2.0"
 kotlin = "2.0.0"
 core-ktx = "1.13.1"
 appcompat = "1.7.0"
-kotlinx-serialization-json = "1.8.0"
 ktor = "2.3.12"
 lottie = "6.4.0"
 material = "1.12.0"
@@ -12,7 +10,6 @@ cardview = "1.0.0"
 constraintlayout = "2.1.4"
 coroutines-core = "1.4.3-native-mt"
 coroutines-android = "1.8.1"
-easypermissions = "3.0.0"
 junit = "4.13.2"
 androidx-junit = "1.2.1"
 espresso-core = "3.6.1"
@@ -22,8 +19,6 @@ security-crypto = "1.1.0-alpha06"
 
 [libraries]
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "security-crypto" }
-koda-core = { module = "ai.koda.mobile.sdk:koda-core", version.ref = "koda-core" }
-koda-core-staging = { module = "ai.koda.mobile.sdk:koda-core-staging", version.ref = "koda-core" }
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
 androidx-core = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
@@ -35,7 +30,6 @@ kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-junit" }
 espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
-kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 ktor-client-serialization-jvm = { module = "io.ktor:ktor-client-serialization-jvm", version.ref = "ktor" }
 ktor-client-serialization-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ koda-core = "1.2.0"
 kotlin = "2.0.0"
 core-ktx = "1.13.1"
 appcompat = "1.7.0"
+kotlinx-serialization-json = "1.8.0"
 ktor = "2.3.12"
 lottie = "6.4.0"
 material = "1.12.0"
@@ -34,6 +35,7 @@ kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-junit" }
 espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 ktor-client-serialization-jvm = { module = "io.ktor:ktor-client-serialization-jvm", version.ref = "ktor" }
 ktor-client-serialization-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -4,7 +4,6 @@ import java.text.SimpleDateFormat
 apply plugin: "com.google.cloud.artifactregistry.gradle-plugin"
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlinx-serialization'
 
 android {
     Properties properties = new Properties()
@@ -83,8 +82,6 @@ dependencies {
 
     implementation libs.kotlinx.coroutines.core
     implementation libs.kotlinx.coroutines.android
-    implementation(libs.kotlinx.serialization.json)
-
 
     testImplementation libs.junit
     androidTestImplementation libs.androidx.junit

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -4,6 +4,7 @@ import java.text.SimpleDateFormat
 apply plugin: "com.google.cloud.artifactregistry.gradle-plugin"
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlinx-serialization'
 
 android {
     Properties properties = new Properties()
@@ -82,6 +83,7 @@ dependencies {
 
     implementation libs.kotlinx.coroutines.core
     implementation libs.kotlinx.coroutines.android
+    implementation(libs.kotlinx.serialization.json)
 
 
     testImplementation libs.junit

--- a/sample/src/main/java/ai/koda/mobile/sdk/sample/GenerateTokenEventParameters.kt
+++ b/sample/src/main/java/ai/koda/mobile/sdk/sample/GenerateTokenEventParameters.kt
@@ -1,0 +1,9 @@
+package ai.koda.mobile.sdk.sample
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GenerateTokenEventParameters(
+    @SerialName("next_block_id") val nextBlockId: String
+)

--- a/sample/src/main/java/ai/koda/mobile/sdk/sample/GenerateTokenEventParameters.kt
+++ b/sample/src/main/java/ai/koda/mobile/sdk/sample/GenerateTokenEventParameters.kt
@@ -1,9 +1,0 @@
-package ai.koda.mobile.sdk.sample
-
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-
-@Serializable
-data class GenerateTokenEventParameters(
-    @SerialName("next_block_id") val nextBlockId: String
-)

--- a/sample/src/main/java/ai/koda/mobile/sdk/sample/MainActivity.kt
+++ b/sample/src/main/java/ai/koda/mobile/sdk/sample/MainActivity.kt
@@ -139,11 +139,9 @@ class MainActivity : AppCompatActivity() {
         binding.activityMainControlsSendBlock.setOnClickListener {
             SendBlockWithParamsDialog(this).also {
                 it.createDialog { blockId, paramKey, paramValue ->
-                    val param = if (listOf(
-                            paramKey,
-                            paramValue
-                        ).all { it.isNotBlank() }
-                    ) mapOf(paramKey to paramValue) else null
+                    val param = if (listOf(paramKey, paramValue).all { it.isNotBlank() })
+                        mapOf(paramKey to paramValue)
+                    else null
                     if (kodaBotsFragment?.sendBlock(
                             blockId,
                             param

--- a/sample/src/main/java/ai/koda/mobile/sdk/sample/MainActivity.kt
+++ b/sample/src/main/java/ai/koda/mobile/sdk/sample/MainActivity.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
 
 class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
@@ -31,6 +32,9 @@ class MainActivity : AppCompatActivity() {
         when (it) {
             is KodaBotsCallbacks.Event -> {
                 Log.d("KodaBotsSample", "CallbackEvent ${it.type} - ${it.params}")
+                when(it.type){
+                    GENERATE_TOKEN_EVENT_TYPE -> handleGenerateTokenEventCallback(it)
+                }
             }
 
             is KodaBotsCallbacks.Error -> {
@@ -166,6 +170,11 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    private fun handleGenerateTokenEventCallback(event: KodaBotsCallbacks.Event){
+        val parameters: GenerateTokenEventParameters = Json.decodeFromString(event.params)
+        kodaBotsFragment?.sendBlock(parameters.nextBlockId, "token-123")
+    }
+
     private fun consumePadding() {
         ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, insets ->
             val bars = insets.getInsets(
@@ -185,5 +194,9 @@ class MainActivity : AppCompatActivity() {
     override fun onDestroy() {
         scope.cancel()
         super.onDestroy()
+    }
+
+    companion object {
+        const val GENERATE_TOKEN_EVENT_TYPE = "web.chatbot.chat.custom.generate_token"
     }
 }

--- a/sample/src/main/java/ai/koda/mobile/sdk/sample/MainActivity.kt
+++ b/sample/src/main/java/ai/koda/mobile/sdk/sample/MainActivity.kt
@@ -139,9 +139,7 @@ class MainActivity : AppCompatActivity() {
         binding.activityMainControlsSendBlock.setOnClickListener {
             SendBlockWithParamsDialog(this).also {
                 it.createDialog { blockId, paramKey, paramValue ->
-                    val param = if (listOf(paramKey, paramValue).all { it.isNotBlank() })
-                        mapOf(paramKey to paramValue)
-                    else null
+                    val param = mapOf(paramKey to paramValue)
                     if (kodaBotsFragment?.sendBlock(
                             blockId,
                             param

--- a/sample/src/main/java/ai/koda/mobile/sdk/sample/SendBlockWithParamsDialog.kt
+++ b/sample/src/main/java/ai/koda/mobile/sdk/sample/SendBlockWithParamsDialog.kt
@@ -1,0 +1,54 @@
+package ai.koda.mobile.sdk.sample
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import com.google.android.material.textfield.TextInputLayout
+
+class SendBlockWithParamsDialog(context: Context) {
+    var mContext: Context? = null
+    var outerCallback: (String, String, String) -> Unit = { _, _, _ -> }
+    var mDialog: AlertDialog? = null
+    var view: View? = null
+
+    init {
+        init(context)
+    }
+
+    private fun init(context: Context) {
+        mContext = context
+        view = LayoutInflater.from(context).inflate(R.layout.dialog_three_edit_text, null, false)
+        view?.findViewById<View>(R.id.dialog_edittext_ok)?.setOnClickListener {
+            outerCallback.invoke(
+                view?.findViewById<TextInputLayout>(R.id.dialog_edittext_input)?.editText?.text.toString(),
+                view?.findViewById<TextInputLayout>(R.id.dialog_edittext_input2)?.editText?.text.toString(),
+                view?.findViewById<TextInputLayout>(R.id.dialog_edittext_input3)?.editText?.text.toString(),
+            )
+            mDialog?.dismiss()
+        }
+        view?.findViewById<View>(R.id.dialog_edittext_cancel)?.setOnClickListener {
+            mDialog?.dismiss()
+        }
+        setText()
+    }
+
+    private fun setText() {
+        view?.findViewById<TextView>(R.id.dialog_edittext_title)?.text =
+            mContext?.getString(R.string.activity_main_controls_send_block).orEmpty()
+        view?.findViewById<TextInputLayout>(R.id.dialog_edittext_input)?.hint = "Block ID"
+        view?.findViewById<TextInputLayout>(R.id.dialog_edittext_input2)?.hint = "Parameter Key"
+        view?.findViewById<TextInputLayout>(R.id.dialog_edittext_input3)?.hint = "Parameter Value"
+    }
+
+
+    fun createDialog(callback: (String, String, String) -> Unit): AlertDialog {
+        outerCallback = callback
+        val builder = AlertDialog.Builder(mContext!!)
+        builder.setView(view)
+        mDialog = builder.create()
+        mDialog?.show()
+        return mDialog!!
+    }
+}

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
     <string name="activity_main_controls_send_block">SEND BLOCK</string>
     <string name="activity_main_controls_simulate_error">SIMULATE ERROR</string>
     <string name="activity_main_snackbar_not_initialized">WEBVIEW NOT INITIALIZED</string>
-    <string name="activity_main_dialog_set_block_id">Set blockId</string>
+    <string name="activity_main_dialog_set_block_id">Set blockId with params</string>
     <string name="activity_main_dialog_sync_profile">Sync profile</string>
     <string name="activity_main_dialog_sync_profile_first_name">First Name</string>
     <string name="activity_main_dialog_sync_profile_last_name">Last Name</string>


### PR DESCRIPTION
This pull request introduces several significant changes to the `ai.koda.mobile.sdk` project, focusing on enhancing the user interface for sending blocks with parameters. 

### Method Enhancements:
* Modified the `sendBlock` method in `KodaBotsWebViewFragment.kt` to accept an optional `params` parameter, which is serialized to JSON before being passed to JavaScript.

### User Interface Improvements:
* Replaced `SingleEditTextDialog` with `SendBlockWithParamsDialog` in `MainActivity.kt` to allow users to input block ID and additional parameters.